### PR TITLE
Added key-features to config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -1197,7 +1197,38 @@
     ]
   },
   "concepts": [],
-  "key_features": [],
+  "key_features": [
+    {
+      "title": "Purely functional",
+      "content": "Pure functions always produce the same output for the same input, so are more predictable.",
+      "icon": "functional"
+    },
+    {
+      "title": "Non-strict",
+      "content": "Lazy evaluation only provides results as needed, allowing for infinite data structures.",
+      "icon": "lazy"
+    },
+    {
+      "title": "Strong, static typing",
+      "content": "Strong, static types mean more errors are caught before the program is run.",
+      "icon": "statically-typed"
+    },
+    {
+      "title": "Type inference",
+      "content": "Automatic inference of types makes the code lighter and the developer more productive.",
+      "icon": "fun"
+    },
+    {
+      "title": "Type classes",
+      "content": "Categorising types into classes provides type-safe overloading.",
+      "icon": "extensible"
+    },
+    {
+      "title": "Algebraic data types",
+      "content": "Powerful data types provide a high degree of convenience and safety.",
+      "icon": "powerful"
+    }
+  ],
   "tags": [
     "paradigm/functional"
   ]

--- a/config.json
+++ b/config.json
@@ -1206,7 +1206,7 @@
     {
       "title": "Non-strict",
       "content": "Lazy evaluation only provides results as needed, allowing for infinite data structures.",
-      "icon": "lazy"
+      "icon": "evolving"
     },
     {
       "title": "Strong, static typing",


### PR DESCRIPTION
Reviving PR [#953](https://github.com/exercism/haskell/pull/953) by @sshine, which was created to resolve [issue #938: Add key features](https://github.com/exercism/haskell/issues/938). The PR already had all six key features written but was closed before it got merged. I started where that PR ended, with the same goal, and have made the following changes:

* Removed "features" prefix from icon names so they match names in the icon library.
* Replaced language-specific jargon, as encouraged in the [spec](https://github.com/exercism/docs/blob/main/building/tracks/config-json.md).
* Changed "lazy" icon for the "Non-strict" feature to "evolving" to match an existing icon that vaguely conveys the concept (ie. planting a seed that will sprout later). The original pull request suggested that referring to icons that don't yet exist is okay, but I'm not confident about the outcome of that, so have erred on the side of working now, modifiable later.
  * Same for "strongly-typed" -> "statically-typed".
  * Same for "type-inference" -> "fun".
  * Same for "type-classes" -> "extensible".
  * Same for "algebraic-data-types" -> "powerful".